### PR TITLE
Add --verbose and --passthrough options to `sls stackstorm docker run`

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -1,4 +1,5 @@
 const child_process = require('child_process');
+const chalk = require('chalk');
 
 module.exports.pullDockerImage = async (dockerImage) => {
   const args = ['pull']
@@ -16,13 +17,13 @@ module.exports.pullDockerImage = async (dockerImage) => {
 
     run.stdout.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       stdout += str;
     });
 
     run.stderr.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       stderr += str;
     });
 
@@ -56,13 +57,13 @@ module.exports.startDocker = async (dockerImage, volume) => {
   return new Promise((resolve, reject) => {
     run.stdout.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       resolve(str.replace(/\n$/, ''));
     });
 
     run.stderr.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       reject(str.replace(/\n$/, ''));
     });
   });
@@ -97,27 +98,39 @@ module.exports.runDocker = async (dockerImage, volumes, envs, cmd) => {
 
     run.stdout.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       stdout += str;
     });
 
     run.stderr.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       stderr += str;
     });
 
     run.on('close', (code) => {
-      const result = {
+      const res = {
         code,
         stdout,
         stderr,
       };
 
+      const lines = stdout.split('\n');
+      if (lines.length > 1 && lines[lines.length - 2]) {
+        try {
+          lines.pop(); // Remove empty element
+          res.result = JSON.parse(lines.pop());
+          lines.push(''); // Put empty element back
+          res.stdout = lines.join('\n');
+        } catch (e) {
+          // If it didn't work, well, ¯\_(ツ)_/¯
+        }
+      }
+
       if (code === 0) {
-        resolve(result);
+        resolve(res);
       } else {
-        reject(result);
+        reject(res);
       }
     });
   });
@@ -139,13 +152,13 @@ module.exports.execDocker = async (dockerId, command) => {
 
     run.stdout.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       stdout += str;
     });
 
     run.stderr.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       stderr += str;
     });
 
@@ -176,13 +189,13 @@ module.exports.stopDocker = async (dockerId) => {
   return new Promise((resolve, reject) => {
     run.stdout.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       resolve(str.replace(/\n$/, ''));
     });
 
     run.stderr.on('data', (data) => {
       const str = data.toString();
-      console.log(str.replace(/\n$/, ''));
+      console.log(chalk.dim(str.replace(/\n$/, '')));
       reject(str.replace(/\n$/, ''));
     });
   });


### PR DESCRIPTION
`--verbose` gives you an overview on all the kind of data transformations happened during the run

```
Incoming event ->
{
  "issue_id": "222"
}
-> Parameter transformer ->
{
  "repo": "st2",
  "issue_id": "222",
  "user": "StackStorm"
}
-> Action call ->
{
  "result": {
    "body": "",
    "labels": [],
    "author": {
      "login": "manasdk",
      "name": "Manas Kelshikar"
    },
    "repository": "st2",
    "title": "[STORM-281] Remove demo sensors.",
    "url": "https://github.com/StackStorm/st2/pull/222",
    "created_at": "2014-07-14T19:25:46.000000+00:00",
    "is_pull_request": true,
    "id": 37818960,
    "state": "closed",
    "closed_at": "2014-07-14T19:25:49.000000+00:00",
    "assign": null,
    "closed_by": {
      "login": "manasdk",
      "name": "Manas Kelshikar"
    }
  },
  "exit_code": 0,
  "stderr": "",
  "stdout": ""
}
-> Output transformer ->
{
  "result": "2014-07-14T19:25:46.000000+00:00"
}
```

`--passthrough` allows you to skip action call and pass the result of parameter transformation directly into output transformation

```
Incoming event ->
{
  "issue_id": "222"
}
-> Parameter transformer ->
{
  "repo": "st2",
  "issue_id": "222",
  "user": "StackStorm"
}
-> Action call (passthrough) ->
{
  "repo": "st2",
  "issue_id": "222",
  "user": "StackStorm"
}
-> Output transformer ->
{
  "result": "StackStorm"
}
```