### PR TITLE
Use expandHomeDir to correctly expand ~ to user home dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,12 @@ const request = require('axios');
 const stdin = require('get-stdin');
 const urljoin = require('url-join');
 const chalk = require('chalk');
+const expandHomeDir = require('expand-home-dir');
 
 const { pullDockerImage, startDocker, runDocker, execDocker, stopDocker } = require('./lib/docker');
 
 
-const MAGIC_FOLDER = '~st2';
+const MAGIC_FOLDER = expandHomeDir('~/st2');
 const INTERNAL_MAGIC_FOLDER = `/var/task/${MAGIC_FOLDER}`;
 const DEFAULT_PYTHON_PATH = [
   `${INTERNAL_MAGIC_FOLDER}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -639,6 +639,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "expand-home-dir": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
+      "integrity": "sha1-ct6KBIbMKKO71wRjU5iCW1tign0="
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -3624,14 +3629,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3640,6 +3637,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "axios": "0.16.2",
     "chalk": "2.3.0",
+    "expand-home-dir": "0.0.3",
     "fs-extra": "4.0.2",
     "get-stdin": "5.0.1",
     "js-yaml": "3.10.0",


### PR DESCRIPTION
path.resolve which is used by `fs-extra` module (https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy/copy.js#L28) doesn't correctly expand `~` to user home here on my system.

```bash
kami ~/serverless-test $ node
> path.resolve('~st2')
'/home/kami/serverless-test/~st2'
> path.resolve('~/st2')
'/home/kami/serverless-test/~/st2'
> path.resolve(process.cwd(), '~st2')
'/home/kami/serverless-test/~st2'
> path.resolve(process.cwd(), '~/st2')
'/home/kami/serverless-test/~/st2'

> expandHomeDir = require('expand-home-dir')
[Function: expandHomeDir]
> expandHomeDir('~/st2')
'/home/kami/st2'
```

