### PR TITLE
Add pack info command

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class StackstormPlugin {
 
         return this.copyAllPacksDeps({ force: true });
       },
-      'stackstorm:info:info': () => this.showActionInfo(this.options.action),
+      'stackstorm:info:info': () => this.showInfo(this.options),
       'before:package:createDeploymentArtifacts': () => this.beforeCreateDeploymentArtifacts(),
       'before:simulate:apigateway:initialize': () => this.beforeCreateDeploymentArtifacts(),
       'before:invoke:local:invoke': () => this.beforeCreateDeploymentArtifacts(true)
@@ -202,8 +202,10 @@ class StackstormPlugin {
             ],
             options: {
               action: {
-                usage: 'Action name',
-                required: true
+                usage: 'Action name'
+              },
+              pack: {
+                usage: 'Pack name'
               }
             }
           }
@@ -414,6 +416,16 @@ class StackstormPlugin {
     return result.result;
   }
 
+  showInfo({ action, pack }) {
+    if (action) {
+      return this.showActionInfo(action);
+    } else if (pack) {
+      return this.showPackInfo(pack);
+    } else {
+      throw new Error('Either action or pack should be provided');
+    }
+  }
+
   async showActionInfo(action) {
     const [ packName, ...actionNameRest ] = action.split('.');
     const actionName = actionNameRest.join('.');
@@ -458,6 +470,31 @@ class StackstormPlugin {
       }
     } catch (e) {
       msg.push(chalk.dim('The action does not require config parameters'));
+    }
+
+    this.serverless.cli.consoleLog(msg.join('\n'));
+  }
+
+  async showPackInfo(packName) {
+    const indexUrl = urljoin(this.index_root, 'index.json');
+    const index = await request.get(indexUrl).then(res => res.data);
+
+    const dots = 30;
+    const indent = '  ';
+
+    const msg = [];
+
+    const pack = index.packs[packName];
+    if (!pack) {
+      throw new Error(`No such pack in the index: ${packName}`);
+    }
+    const usage = pack.description || chalk.dim('pack description is missing');
+    const { actions={} } = pack.content;
+
+    msg.push(`${chalk.yellow(packName)} ${chalk.dim(_.repeat('.', dots - packName.length))} ${usage}`);
+    msg.push(`${chalk.yellow.underline('Actions')}`);
+    for (let name of actions.resources) {
+      msg.push(`${indent}${name}`);
     }
 
     this.serverless.cli.consoleLog(msg.join('\n'));

--- a/index.test.js
+++ b/index.test.js
@@ -693,4 +693,74 @@ describe('index', () => {
       ].join('\n'));
     });
   });
+
+  describe('#showPackInfo', () => {
+    it('should display pack help', async () => {
+      const getStub = sinon.stub();
+
+      getStub
+        .withArgs('https://index.stackstorm.org/v1/index.json')
+        .resolves({
+          'data': {
+            'metadata': {
+              'generated_ts': 1512633599,
+              'hash': '72c7655b059b387f074ea0a868b54a2f'
+            },
+            'packs': {
+              'test': {
+                'author': 'st2-dev',
+                'content': {
+                  'actions': {
+                    'count': 2,
+                    'resources': [
+                      'list_vms',
+                      'parse'
+                    ]
+                  },
+                  'tests': {
+                    'count': 1,
+                    'resources': [
+                      'test_action_parse_xml.py'
+                    ]
+                  }
+                },
+                'description': 'st2 pack to test package management pipeline',
+                'email': 'info@stackstorm.com',
+                'keywords': [
+                  'some',
+                  'search',
+                  'terms'
+                ],
+                'name': 'test',
+                'repo_url': 'https://github.com/StackStorm-Exchange/stackstorm-test',
+                'version': '0.4.0'
+              }
+            }
+          }
+        });
+
+      const StackStorm = mock('./index.js', {
+        'axios': {
+          get: getStub
+        }
+      });
+
+      const serverless = {
+        ...sls,
+        cli: {
+          consoleLog: sinon.spy()
+        }
+      };
+
+      const instance = new StackStorm(serverless, opts);
+
+      await expect(instance.showPackInfo('test')).to.eventually.be.fulfilled;
+      expect(serverless.cli.consoleLog).to.be.calledWith([
+        '\u001b[33mtest\u001b[39m \u001b[2m..........................\u001b[22m st2 pack to test package management pipeline',
+        '\u001b[33m\u001b[4mActions\u001b[24m\u001b[39m',
+        '  list_vms',
+        '  parse'
+      ].join('\n'));
+    });
+  });
 });


### PR DESCRIPTION
```
$ sls stackstorm info --pack acos
acos .......................... StackStorm pack for ACOS-based appliances of A10 Networks.
Actions
  add_slb_server
  add_slb_server_port
  add_slb_service_group
  add_slb_service_group_member
  add_slb_virtual_server
  add_slb_virtual_server_port
  del_slb_server
  del_slb_server_port
  del_slb_service_group
  del_slb_service_group_member
  del_slb_virtual_server
  del_slb_virtual_server_port
  get_slb_server
  get_slb_service_group
  get_slb_service_group_members
  get_slb_virtual_server
  list_slb_servers
  list_slb_service_groups
  list_slb_virtual_servers
```