### PR TITLE
pip install fix and handler content-type fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@ class StackstormPlugin {
     await this.execDocker([
       '/bin/bash', '-c',
       `PYTHONPATH=$PYTHONPATH:${pythonpath} ` +
-      `pip --isolated install -r ${requirements} --prefix ${prefix} --src ${prefix}/src`
+      `pip --isolated install --ignore-installed -r ${requirements} --prefix ${prefix} --src ${prefix}/src`
     ], { noPull });
   }
 

--- a/index.test.js
+++ b/index.test.js
@@ -185,7 +185,7 @@ describe('index', () => {
       expect(execStub).to.be.calledWith(instance.dockerId, [
         '/bin/bash', '-c',
         'PYTHONPATH=$PYTHONPATH:/var/task/~st2/virtualenvs/dummypack/lib/python2.7/site-packages ' +
-        'pip --isolated install -r /var/task/~st2/packs/dummypack/requirements.txt ' +
+        'pip --isolated install --ignore-installed -r /var/task/~st2/packs/dummypack/requirements.txt ' +
         '--prefix /var/task/~st2/virtualenvs/dummypack --src /var/task/~st2/virtualenvs/dummypack/src'
       ]);
     });

--- a/stackstorm/handler.py
+++ b/stackstorm/handler.py
@@ -135,16 +135,19 @@ def base(event, context, passthrough=False):
     # #example-lambda-proxy-event-default
     # for details
     is_event_body_string = (isinstance(event.get('body'), basestring) is True)
-    content_type = event.get('headers', {}).get('Content-Type', '').lower()
+    content_type = event.get('headers', {}).get('content-type', '').lower()
 
     if is_event_body_string:
         if content_type == 'application/json':
             try:
                 event['body'] = json.loads(event['body'])
-            except Exception:
-                LOG.warn('`event` has `body` which is not JSON')
+            except Exception as e:
+                LOG.warn('`event` has `body` which is not JSON: %s', str(e.message))
         elif content_type == 'application/x-www-form-urlencoded':
-            event['body'] = dict(parse_qsl(['body'], keep_blank_values=True))
+            try:
+                event['body'] = dict(parse_qsl(['body'], keep_blank_values=True))
+            except Exception as e:
+                LOG.warn('`event` has `body` which is not `%s`: %s', content_type, str(e.message))
         else:
             LOG.warn('Unsupported event content type: %s' % (content_type))
 


### PR DESCRIPTION
Three bug fixes in this PR:
1) "Requirement already satisfied: boto3>=1.5 in /var/runtime". My action wouldn't work because it complained that boto3 was missing even though it was added to pack's requirements.txt. Adding '--ignore-installed' fixed the issue.
2) 'Content-Type' is actually 'content-type' in the lambda dataset. See: https://serverless.com/framework/docs/providers/aws/events/apigateway/#example-lambda-proxy-event-default
3) Exception handling for 'x-www-form-urlencoded' content-type.