### PR TITLE
Disable output streaming since it breaks the plugin

### DIFF
--- a/stackstorm/st2.conf
+++ b/stackstorm/st2.conf
@@ -18,3 +18,4 @@ api_url = None
 
 [actionrunner]
 logging = ~st2/console.conf
+stream_output = False


### PR DESCRIPTION
This plugin doesn't work with StackStorm >= 2.6.0 where output streaming is enabled by default.

This pull request fixes that by disabling output streaming (output streaming functionality is not required for this plugin to work).

Resolves #32.

Thanks to @tsblack for reporting this issue.